### PR TITLE
Use generic RGB color space when converting from/to HEX color representation

### DIFF
--- a/Core/Source/DTColorFunctions.m
+++ b/Core/Source/DTColorFunctions.m
@@ -25,22 +25,6 @@ NSUInteger _integerValueFromHexString(NSString *hexString)
 	return result;
 }
 
-//- (BOOL)isNumeric
-//{
-//	const char *s = [self UTF8String];
-//	
-//	for (size_t i=0;i<strlen(s);i++)
-//	{
-//		if ((s[i]<'0' || s[i]>'9') && (s[i] != '.'))
-//		{
-//			return NO;
-//		}
-//	}
-//	
-//	return YES;
-//}
-
-
 DTColor *DTColorCreateWithHexString(NSString *hexString)
 {
 	if ([hexString length]!=6 && [hexString length]!=3)
@@ -58,11 +42,13 @@ DTColor *DTColorCreateWithHexString(NSString *hexString)
 	CGFloat red = redValue/maxValue;
 	CGFloat green = greenValue/maxValue;
 	CGFloat blue = blueValue/maxValue;
+    CGFloat alpha = 1.0;
 	
 #if TARGET_OS_IPHONE
-	return [DTColor colorWithRed:red green:green blue:blue alpha:1.0];
+	return [DTColor colorWithRed:red green:green blue:blue alpha:alpha];
 #else
-	return (DTColor *)[NSColor colorWithDeviceRed:red green:green blue:blue alpha:1.0];
+    CGFloat components[4] = {red, green, blue, alpha};
+    return [NSColor colorWithColorSpace:[NSColorSpace genericRGBColorSpace] components:components count:4];
 #endif
 }
 
@@ -84,15 +70,16 @@ DTColor *DTColorCreateWithHTMLName(NSString *name)
 			return nil;
 		}
 		
-		CGFloat red = (CGFloat)[[rgba objectAtIndex:0] floatValue] / 255;
-		CGFloat green = [[rgba objectAtIndex:1] floatValue] / 255;
-		CGFloat blue = [[rgba objectAtIndex:2] floatValue] / 255;
-		CGFloat alpha = [[rgba objectAtIndex:3] floatValue];
+		CGFloat red = (CGFloat)[rgba[0] floatValue] / 255;
+		CGFloat green = [rgba[1] floatValue] / 255;
+		CGFloat blue = [rgba[2] floatValue] / 255;
+		CGFloat alpha = [rgba[3] floatValue];
 		
 #if TARGET_OS_IPHONE
 		return [DTColor colorWithRed:red green:green blue:blue alpha:alpha];
 #else
-		return (DTColor *)[NSColor colorWithDeviceRed:red green:green blue:blue alpha:alpha];
+        CGFloat components[4] = {red, green, blue, alpha};
+        return [NSColor colorWithColorSpace:[NSColorSpace genericRGBColorSpace] components:components count:4];
 #endif
 	}
 	
@@ -107,198 +94,199 @@ DTColor *DTColorCreateWithHTMLName(NSString *name)
 			return nil;
 		}
 		
-		CGFloat red = [[rgb objectAtIndex:0] floatValue] / 255;
-		CGFloat green = [[rgb objectAtIndex:1] floatValue] / 255;
-		CGFloat blue = [[rgb objectAtIndex:2] floatValue] / 255;
+		CGFloat red = [rgb[0] floatValue] / 255;
+		CGFloat green = [rgb[1] floatValue] / 255;
+		CGFloat blue = [rgb[2] floatValue] / 255;
 		CGFloat alpha = 1.0;
 		
 #if TARGET_OS_IPHONE
 		return [DTColor colorWithRed:red green:green blue:blue alpha:alpha];
 #else
-		return (DTColor *)[NSColor colorWithDeviceRed:red green:green blue:blue alpha:alpha];
+        CGFloat components[4] = {red, green, blue, alpha};
+        return (DTColor *)[NSColor colorWithColorSpace:[NSColorSpace genericRGBColorSpace] components:components count:4];
 #endif
 	}
 	
 	static dispatch_once_t predicate;
 	dispatch_once(&predicate, ^{
-		colorLookup = [[NSDictionary alloc] initWithObjectsAndKeys:
-							@"F0F8FF", @"aliceblue",
-							@"FAEBD7", @"antiquewhite",
-							@"00FFFF", @"aqua",
-							@"7FFFD4", @"aquamarine",
-							@"F0FFFF", @"azure",
-							@"F5F5DC", @"beige",
-							@"FFE4C4", @"bisque",
-							@"000000", @"black",
-							@"FFEBCD", @"blanchedalmond",
-							@"0000FF", @"blue",
-							@"8A2BE2", @"blueviolet",
-							@"A52A2A", @"brown",
-							@"DEB887", @"burlywood",
-							@"5F9EA0", @"cadetblue",
-							@"7FFF00", @"chartreuse",
-							@"D2691E", @"chocolate",
-							@"FF7F50", @"coral",
-							@"6495ED", @"cornflowerblue",
-							@"FFF8DC", @"cornsilk",
-							@"DC143C", @"crimson",
-							@"00FFFF", @"cyan",
-							@"00008B", @"darkblue",
-							@"008B8B", @"darkcyan",
-							@"B8860B", @"darkgoldenrod",
-							@"A9A9A9", @"darkgray",
-							@"A9A9A9", @"darkgrey",
-							@"006400", @"darkgreen",
-							@"BDB76B", @"darkkhaki",
-							@"8B008B", @"darkmagenta",
-							@"556B2F", @"darkolivegreen",
-							@"FF8C00", @"darkorange",
-							@"9932CC", @"darkorchid",
-							@"8B0000", @"darkred",
-							@"E9967A", @"darksalmon",
-							@"8FBC8F", @"darkseagreen",
-							@"483D8B", @"darkslateblue",
-							@"2F4F4F", @"darkslategray",
-							@"2F4F4F", @"darkslategrey",
-							@"00CED1", @"darkturquoise",
-							@"9400D3", @"darkviolet",
-							@"FF1493", @"deeppink",
-							@"00BFFF", @"deepskyblue",
-							@"696969", @"dimgray",
-							@"696969", @"dimgrey",
-							@"1E90FF", @"dodgerblue",
-							@"B22222", @"firebrick",
-							@"FFFAF0", @"floralwhite",
-							@"228B22", @"forestgreen",
-							@"FF00FF", @"fuchsia",
-							@"DCDCDC", @"gainsboro",
-							@"F8F8FF", @"ghostwhite",
-							@"FFD700", @"gold",
-							@"DAA520", @"goldenrod",
-							@"808080", @"gray",
-							@"808080", @"grey",
-							@"008000", @"green",
-							@"ADFF2F", @"greenyellow",
-							@"F0FFF0", @"honeydew",
-							@"FF69B4", @"hotpink",
-							@"CD5C5C", @"indianred",
-							@"4B0082", @"indigo",
-							@"FFFFF0", @"ivory",
-							@"F0E68C", @"khaki",
-							@"E6E6FA", @"lavender",
-							@"FFF0F5", @"lavenderblush",
-							@"7CFC00", @"lawngreen",
-							@"FFFACD", @"lemonchiffon",
-							@"ADD8E6", @"lightblue",
-							@"F08080", @"lightcoral",
-							@"E0FFFF", @"lightcyan",
-							@"FAFAD2", @"lightgoldenrodyellow",
-							@"D3D3D3", @"lightgray",
-							@"D3D3D3", @"lightgrey",
-							@"90EE90", @"lightgreen",
-							@"FFB6C1", @"lightpink",
-							@"FFA07A", @"lightsalmon",
-							@"20B2AA", @"lightseagreen",
-							@"87CEFA", @"lightskyblue",
-							@"778899", @"lightslategray",
-							@"778899", @"lightslategrey",
-							@"B0C4DE", @"lightsteelblue",
-							@"FFFFE0", @"lightyellow",
-							@"00FF00", @"lime",
-							@"32CD32", @"limegreen",
-							@"FAF0E6", @"linen",
-							@"FF00FF", @"magenta",
-							@"800000", @"maroon",
-							@"66CDAA", @"mediumaquamarine",
-							@"0000CD", @"mediumblue",
-							@"BA55D3", @"mediumorchid",
-							@"9370D8", @"mediumpurple",
-							@"3CB371", @"mediumseagreen",
-							@"7B68EE", @"mediumslateblue",
-							@"00FA9A", @"mediumspringgreen",
-							@"48D1CC", @"mediumturquoise",
-							@"C71585", @"mediumvioletred",
-							@"191970", @"midnightblue",
-							@"F5FFFA", @"mintcream",
-							@"FFE4E1", @"mistyrose",
-							@"FFE4B5", @"moccasin",
-							@"FFDEAD", @"navajowhite",
-							@"000080", @"navy",
-							@"FDF5E6", @"oldlace",
-							@"808000", @"olive",
-							@"6B8E23", @"olivedrab",
-							@"FFA500", @"orange",
-							@"FF4500", @"orangered",
-							@"DA70D6", @"orchid",
-							@"EEE8AA", @"palegoldenrod",
-							@"98FB98", @"palegreen",
-							@"AFEEEE", @"paleturquoise",
-							@"D87093", @"palevioletred",
-							@"FFEFD5", @"papayawhip",
-							@"FFDAB9", @"peachpuff",
-							@"CD853F", @"peru",
-							@"FFC0CB", @"pink",
-							@"DDA0DD", @"plum",
-							@"B0E0E6", @"powderblue",
-							@"800080", @"purple",
-							@"FF0000", @"red",
-							@"BC8F8F", @"rosybrown",
-							@"4169E1", @"royalblue",
-							@"8B4513", @"saddlebrown",
-							@"FA8072", @"salmon",
-							@"F4A460", @"sandybrown",
-							@"2E8B57", @"seagreen",
-							@"FFF5EE", @"seashell",
-							@"A0522D", @"sienna",
-							@"C0C0C0", @"silver",
-							@"87CEEB", @"skyblue",
-							@"6A5ACD", @"slateblue",
-							@"708090", @"slategray",
-							@"708090", @"slategrey",
-							@"FFFAFA", @"snow",
-							@"00FF7F", @"springgreen",
-							@"4682B4", @"steelblue",
-							@"D2B48C", @"tan",
-							@"008080", @"teal",
-							@"D8BFD8", @"thistle",
-							@"FF6347", @"tomato",
-							@"40E0D0", @"turquoise",
-							@"EE82EE", @"violet",
-							@"F5DEB3", @"wheat",
-							@"FFFFFF", @"white",
-							@"F5F5F5", @"whitesmoke",
-							@"FFFF00", @"yellow",
-							@"9ACD32", @"yellowgreen",
-							nil];
+		colorLookup = @{@"aliceblue" : @"F0F8FF",
+				@"antiquewhite" : @"FAEBD7",
+				@"aqua" : @"00FFFF",
+				@"aquamarine" : @"7FFFD4",
+				@"azure" : @"F0FFFF",
+				@"beige" : @"F5F5DC",
+				@"bisque" : @"FFE4C4",
+				@"black" : @"000000",
+				@"blanchedalmond" : @"FFEBCD",
+				@"blue" : @"0000FF",
+				@"blueviolet" : @"8A2BE2",
+				@"brown" : @"A52A2A",
+				@"burlywood" : @"DEB887",
+				@"cadetblue" : @"5F9EA0",
+				@"chartreuse" : @"7FFF00",
+				@"chocolate" : @"D2691E",
+				@"coral" : @"FF7F50",
+				@"cornflowerblue" : @"6495ED",
+				@"cornsilk" : @"FFF8DC",
+				@"crimson" : @"DC143C",
+				@"cyan" : @"00FFFF",
+				@"darkblue" : @"00008B",
+				@"darkcyan" : @"008B8B",
+				@"darkgoldenrod" : @"B8860B",
+				@"darkgray" : @"A9A9A9",
+				@"darkgrey" : @"A9A9A9",
+				@"darkgreen" : @"006400",
+				@"darkkhaki" : @"BDB76B",
+				@"darkmagenta" : @"8B008B",
+				@"darkolivegreen" : @"556B2F",
+				@"darkorange" : @"FF8C00",
+				@"darkorchid" : @"9932CC",
+				@"darkred" : @"8B0000",
+				@"darksalmon" : @"E9967A",
+				@"darkseagreen" : @"8FBC8F",
+				@"darkslateblue" : @"483D8B",
+				@"darkslategray" : @"2F4F4F",
+				@"darkslategrey" : @"2F4F4F",
+				@"darkturquoise" : @"00CED1",
+				@"darkviolet" : @"9400D3",
+				@"deeppink" : @"FF1493",
+				@"deepskyblue" : @"00BFFF",
+				@"dimgray" : @"696969",
+				@"dimgrey" : @"696969",
+				@"dodgerblue" : @"1E90FF",
+				@"firebrick" : @"B22222",
+				@"floralwhite" : @"FFFAF0",
+				@"forestgreen" : @"228B22",
+				@"fuchsia" : @"FF00FF",
+				@"gainsboro" : @"DCDCDC",
+				@"ghostwhite" : @"F8F8FF",
+				@"gold" : @"FFD700",
+				@"goldenrod" : @"DAA520",
+				@"gray" : @"808080",
+				@"grey" : @"808080",
+				@"green" : @"008000",
+				@"greenyellow" : @"ADFF2F",
+				@"honeydew" : @"F0FFF0",
+				@"hotpink" : @"FF69B4",
+				@"indianred" : @"CD5C5C",
+				@"indigo" : @"4B0082",
+				@"ivory" : @"FFFFF0",
+				@"khaki" : @"F0E68C",
+				@"lavender" : @"E6E6FA",
+				@"lavenderblush" : @"FFF0F5",
+				@"lawngreen" : @"7CFC00",
+				@"lemonchiffon" : @"FFFACD",
+				@"lightblue" : @"ADD8E6",
+				@"lightcoral" : @"F08080",
+				@"lightcyan" : @"E0FFFF",
+				@"lightgoldenrodyellow" : @"FAFAD2",
+				@"lightgray" : @"D3D3D3",
+				@"lightgrey" : @"D3D3D3",
+				@"lightgreen" : @"90EE90",
+				@"lightpink" : @"FFB6C1",
+				@"lightsalmon" : @"FFA07A",
+				@"lightseagreen" : @"20B2AA",
+				@"lightskyblue" : @"87CEFA",
+				@"lightslategray" : @"778899",
+				@"lightslategrey" : @"778899",
+				@"lightsteelblue" : @"B0C4DE",
+				@"lightyellow" : @"FFFFE0",
+				@"lime" : @"00FF00",
+				@"limegreen" : @"32CD32",
+				@"linen" : @"FAF0E6",
+				@"magenta" : @"FF00FF",
+				@"maroon" : @"800000",
+				@"mediumaquamarine" : @"66CDAA",
+				@"mediumblue" : @"0000CD",
+				@"mediumorchid" : @"BA55D3",
+				@"mediumpurple" : @"9370D8",
+				@"mediumseagreen" : @"3CB371",
+				@"mediumslateblue" : @"7B68EE",
+				@"mediumspringgreen" : @"00FA9A",
+				@"mediumturquoise" : @"48D1CC",
+				@"mediumvioletred" : @"C71585",
+				@"midnightblue" : @"191970",
+				@"mintcream" : @"F5FFFA",
+				@"mistyrose" : @"FFE4E1",
+				@"moccasin" : @"FFE4B5",
+				@"navajowhite" : @"FFDEAD",
+				@"navy" : @"000080",
+				@"oldlace" : @"FDF5E6",
+				@"olive" : @"808000",
+				@"olivedrab" : @"6B8E23",
+				@"orange" : @"FFA500",
+				@"orangered" : @"FF4500",
+				@"orchid" : @"DA70D6",
+				@"palegoldenrod" : @"EEE8AA",
+				@"palegreen" : @"98FB98",
+				@"paleturquoise" : @"AFEEEE",
+				@"palevioletred" : @"D87093",
+				@"papayawhip" : @"FFEFD5",
+				@"peachpuff" : @"FFDAB9",
+				@"peru" : @"CD853F",
+				@"pink" : @"FFC0CB",
+				@"plum" : @"DDA0DD",
+				@"powderblue" : @"B0E0E6",
+				@"purple" : @"800080",
+				@"red" : @"FF0000",
+				@"rosybrown" : @"BC8F8F",
+				@"royalblue" : @"4169E1",
+				@"saddlebrown" : @"8B4513",
+				@"salmon" : @"FA8072",
+				@"sandybrown" : @"F4A460",
+				@"seagreen" : @"2E8B57",
+				@"seashell" : @"FFF5EE",
+				@"sienna" : @"A0522D",
+				@"silver" : @"C0C0C0",
+				@"skyblue" : @"87CEEB",
+				@"slateblue" : @"6A5ACD",
+				@"slategray" : @"708090",
+				@"slategrey" : @"708090",
+				@"snow" : @"FFFAFA",
+				@"springgreen" : @"00FF7F",
+				@"steelblue" : @"4682B4",
+				@"tan" : @"D2B48C",
+				@"teal" : @"008080",
+				@"thistle" : @"D8BFD8",
+				@"tomato" : @"FF6347",
+				@"turquoise" : @"40E0D0",
+				@"violet" : @"EE82EE",
+				@"wheat" : @"F5DEB3",
+				@"white" : @"FFFFFF",
+				@"whitesmoke" : @"F5F5F5",
+				@"yellow" : @"FFFF00",
+				@"yellowgreen" : @"9ACD32"};
 	});
 	
-	NSString *hexString = [colorLookup objectForKey:[name lowercaseString]];
+	NSString *hexString = colorLookup[[name lowercaseString]];
 	
 	return DTColorCreateWithHexString(hexString);
 }
 
 NSString *DTHexStringFromDTColor(DTColor *color)
 {
-	CGColorRef cgColor = color.CGColor;
+	CGColorRef cgColor = [color colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]].CGColor;
 	size_t count = CGColorGetNumberOfComponents(cgColor);
 	const CGFloat *components = CGColorGetComponents(cgColor);
-	
+
 	static NSString *stringFormat = @"%02x%02x%02x";
-	
+
 	// Grayscale
 	if (count == 2)
 	{
-		NSUInteger white = (NSUInteger)(components[0] * (CGFloat)255);
+		NSUInteger white = (NSUInteger) (components[0] * (CGFloat) 255);
 		return [NSString stringWithFormat:stringFormat, white, white, white];
 	}
-	
+
 	// RGB
 	else if (count == 4)
 	{
-		return [NSString stringWithFormat:stringFormat, (NSUInteger)(components[0] * (CGFloat)255),
-				  (NSUInteger)(components[1] * (CGFloat)255), (NSUInteger)(components[2] * (CGFloat)255)];
+		return [NSString stringWithFormat:stringFormat,
+						(NSUInteger) (components[0] * (CGFloat) 255),
+						(NSUInteger) (components[1] * (CGFloat) 255),
+						(NSUInteger) (components[2] * (CGFloat) 255)];
 	}
-	
+
 	// Unsupported color space
 	return nil;
 }


### PR DESCRIPTION
Use generic RGB color space when converting from/to HEX color representation

Make sure we use the same color space for encoding/decoding of hex color values.

Plus:
- Cleanup
- Modern syntax
